### PR TITLE
package.json: use a fixed eslint version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@typescript-eslint/eslint-plugin": "^8.6.0",
         "@typescript-eslint/parser": "^8.6.0",
         "@vercel/ncc": "^0.38.1",
-        "eslint": "^8.57.0",
+        "eslint": "=8.57.0",
         "eslint-plugin-jsonc": "^2.16.0",
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/eslint-plugin": "^8.6.0",
     "@typescript-eslint/parser": "^8.6.0",
     "@vercel/ncc": "^0.38.1",
-    "eslint": "^8.57.0",
+    "eslint": "=8.57.0",
     "eslint-plugin-jsonc": "^2.16.0",
     "eslint-plugin-prettier": "^5.2.1",
     "prettier": "^3.3.3",


### PR DESCRIPTION
The more recent version of eslint (currently 9.11.1) seems to changes how the configuration works.
We will see how GitHub tackles this [in their template repo][1].

[1]: https://github.com/actions/typescript-action/pull/950